### PR TITLE
fix: add .releaserc.json

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,3 @@
+{
+    "preset": "conventionalcommits"
+}


### PR DESCRIPTION
The first try didn't work because 'chore' wasn't associated with a patch release