### PR TITLE
fix: end to end tests are missing from the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,11 @@
         "config/*.json",
         "lib",
         "scripts/*.d.ts",
-        "scripts/*.js"
+        "scripts/*.js",
+        "test/e2e"
     ],
     "scripts": {
-        "postpack": "del-cli eslint.config.d.ts config/*.d.ts  lib/*.d.ts scripts/*.d.ts",
+        "postpack": "del-cli *.d.ts config/*.d.ts  lib/**/*.d.ts scripts/*.d.ts test/**/*.d.ts",
         "prepack": "tsc",
         "prettier": "prettier --write \"**/*.json\" \"**/*.js\"",
         "test": "npm run test:unit && npm run test:e2e",

--- a/scripts/upgrade.js
+++ b/scripts/upgrade.js
@@ -48,6 +48,11 @@ const upgrade = async (sdkPath, projectType) => {
     projectPackage.devDependencies[`@vertigis/${projectType}`] = `^${latestProduct}`;
     projectPackage.devDependencies[`@vertigis/${projectType}-sdk`] = `^${latestSDK}`;
 
+    // This is the current minimum version of typescript required by the SDK
+    // build system. If you change it, also change the upgrade test to check for
+    // the new version.
+    projectPackage.devDependencies.typescript = "^5.4.0";
+
     // Check for old eslint configuration and fix it.
     if (fs.existsSync(".eslintrc.js") && !fs.existsSync("eslint.config.js")) {
         console.info("Adding new default configuration for eslint to 'eslint.config.js'.");

--- a/test/e2e/tests.js
+++ b/test/e2e/tests.js
@@ -467,6 +467,12 @@ async function testUpgradeProject() {
         "Project type should be set to 'module'."
     );
 
+    assert.strictEqual(
+        projectPackage.devDependencies.typescript,
+        "^5.4.0",
+        "Minimum typescript version required by the SDK build should be 5.4"
+    )
+
     fs.rmSync(projectPath, { recursive: true })
 }
 


### PR DESCRIPTION
Some miscellaneous fixes:
- end to end tests got left out of the package
- minimum supported version of typescript added to upgrade script + test