### PR TITLE
fix: start script test is broken in workflow sdk

### DIFF
--- a/test/e2e/tests.js
+++ b/test/e2e/tests.js
@@ -361,7 +361,7 @@ async function testActivityPackMetadataGeneration() {
 }
 
 async function testStartProject() {
-    subprocess = runNpmScript(["start"], { cwd: process.env.TEST_PROJECT_PATH });
+    subprocess = runNpmScript(["start", "--type", "http"], { cwd: process.env.TEST_PROJECT_PATH });
 
     // Wait for webpack-dev-server to start. It can take some time!
     await new Promise(resolve => {


### PR DESCRIPTION
Accidentally broke the start script test in `vertigis-workflow-sdk` with the last update.