### PR TITLE
fix: audit issues in js-yaml and nanoid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3167,9 +3167,9 @@
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -14943,9 +14943,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "funding": [
                 {
                     "type": "github",
@@ -15485,9 +15485,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",


### PR DESCRIPTION
Manually fixing these because dependabot has some issues.

FYI: here's the reasoning behind why dependabot won't upgrade js-yaml

```
The latest possible version that can be installed is 3.15.0 because of the following conflicting dependency:

A patched version exists for js-yaml, but the available update path would downgrade jest from 30.4.2 to 25.0.0 because:
The following packages currently require js-yaml through these dependency edges:
  - eslint-plugin-jest: requires js-yaml@^4.3.0 (via @eslint/eslintrc@3.3.6) and js-yaml@^3.13.1 (via @istanbuljs/load-nyc-config@1.1.0)
  - jest: requires js-yaml@^3.13.1 (via @istanbuljs/load-nyc-config@1.1.0)

These edges help explain why npm selected a downgrade path. To resolve this, either:
  1. Update eslint-plugin-jest, jest to versions that support the patched js-yaml, or
  2. Add an override/resolution to pin js-yaml to a non-vulnerable version compatible with your dependencies

The earliest fixed version is 3.15.1.
```

It's saying that it would have to downgrade jest because `^3.13.1` is not resolvable with `3.15.1`. I don't understand how it is making such a basic error here, and not for the first time either.